### PR TITLE
ci: fix github action building docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        apt-get update -yqq && apt-get install -yqq --no-install-recommends libsndfile1
+        sudo apt-get update -yqq && apt-get install -yqq --no-install-recommends libsndfile1
         pip install ."[doc]"
     - name: Build documentation
       run: |


### PR DESCRIPTION
Turns out the images on GHA DO require sudo for apt-get, etc